### PR TITLE
Adding chain runner inside workflow

### DIFF
--- a/.github/workflows/e2e_Test.yml
+++ b/.github/workflows/e2e_Test.yml
@@ -25,8 +25,8 @@ jobs:
         cachix use crypto-com
         cd chain-main 
         cp ./config.yaml.example ./config.yaml
-        nix-shell ./. -A ci-shell --run "pystarport serve"
-        
+        nix-shell ./. -A ci-shell --run "pystarport serve &"
+
     - name: STEP-2 :Setup JSLIB project
       uses: actions/checkout@v2
       with:
@@ -41,6 +41,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node${{ matrix.code }}-${{ hashFiles('**/package-lock.json') }}
     - run: |
+        sleep 5
         curl --location --request GET 'localhost:26657/status'
         cd jslib
         npm install 


### PR DESCRIPTION
- Starting a full node using `pystarport` inside workflow environment