### PR TITLE
Replace default export on top level with object export work-around

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -9,7 +9,7 @@ import { Units } from './coin/coin';
 // By default it is 20. Here we explicitly set it to 20 for correctness.
 Big.DP = 20;
 
-export default {
+const _ = {
     utils,
     HDKey,
     Secp256k1KeyPair,
@@ -17,3 +17,5 @@ export default {
     CroNetwork,
     Units,
 };
+
+export = _;


### PR DESCRIPTION
- Previously on the user side, they had to call `.default` on lib import
`const sdk = require('chain-jslib').default`

- Now that's not needed anymore, it will now work just as expected.
`const sdk = require('chain-jslib')
`