### PR TITLE
Prepare for lib release - Update build setup to copy generated protos

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/crypto-com/chain-jslib-nextgen#readme",
   "scripts": {
-    "prebuild": "mkdir -p lib/dist/cosmos/v1beta1/codec/ && cp -a lib/src/cosmos/v1beta1/codec/generated/  lib/dist/cosmos/v1beta1/codec/",
+    "prebuild": "mkdir -p lib/dist/cosmos/v1beta1/codec/generated/ && cp -a lib/src/cosmos/v1beta1/codec/generated/.  lib/dist/cosmos/v1beta1/codec/generated/",
     "build": "tsc",
     "lint": "eslint 'lib/**'",
     "test:watch": "nodemon",


### PR DESCRIPTION

A week ago when I was doing local npm registry releases and testing I realized initially that proto js files were missing in the output build.

- @calvinaco suggested to turn the config of `allowJs` to `true`, this worked fine and it produced a working build that I was able to test.
- One issue with that config is the fact that `tsc` would output a lot of warnings and errors when `allowJs` was turned on and it was a known issue.
https://github.com/microsoft/TypeScript/issues/37832

- The solution in this PR involves just moving the generated folder to the output directory same technique being used by `cosmjs` and it has worked really great in the tests I have done so far