### PR TITLE
add client wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ coverage
 
 # Generated docs file
 docs/dist/
+
+# Yarn
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -125,6 +125,33 @@ console.log(signedTx.getHexEncoded());
 // Note that the result of signedTx.getHexEncoded() can be directly broadcasted to the network as a raw tx
 ```
 
+### 1.4. Sending transactions 📨
+
+The SDK uses cosmjs stargate client to send transactions. For more information, check
+https://github.com/cosmos/cosmjs/tree/main/packages/stargate
+
+```javascript
+// Imports
+const sdk = require("@crypto-com/chain-jslib");
+const cro = sdk.CroSDK({ network: sdk.CroNetwork.Testnet });
+const client = await cro.CroClient.connect();
+await client.broadcastTx(signedTx.encode().toUint8Array());
+```
+
+### 1.5. Query the chain ❓
+The SDK uses cosmjs queryclient to query the blockchain. For more information, check
+https://github.com/cosmos/cosmjs/tree/main/packages/stargate/src/queries
+
+```javascript
+// Imports
+const sdk = require("@crypto-com/chain-jslib");
+const cro = sdk.CroSDK({ network: sdk.CroNetwork.Testnet });
+const client = await cro.CroClient.connect();
+const queryResult = await client.query().<module>.<operation>
+// example client.query().bank.allBalances(<address>)
+```
+
+
 ## 2. Cosmos Protobuf Definitions
 
 ### Generate Cosmos Protobuf Definitions in JavaScript

--- a/lib/e2e/transaction.spec.ts
+++ b/lib/e2e/transaction.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import Big from 'big.js';
 import { expect } from 'chai';
-import { StargateClient, assertIsBroadcastTxSuccess } from '@cosmjs/stargate';
+import { assertIsBroadcastTxSuccess } from '@cosmjs/stargate';
 import axios from 'axios';
 
 import { HDKey } from '../src/hdkey/hdkey';
@@ -25,6 +25,7 @@ const customNetwork: Network = {
         coinType: 1,
         account: 0,
     },
+    rpcUrl: 'http://localhost:26657',
 };
 
 const testNode = {
@@ -72,7 +73,7 @@ describe('e2e test suite', function () {
         const address1 = new cro.Address(keyPair.getPubKey());
         const address2 = new cro.Address(keyPair2.getPubKey());
         const randomAddress = new cro.Address(randomKeyPair.getPubKey());
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         const msgSend1 = new cro.bank.MsgSend({
             fromAddress: address1.account(),
@@ -139,7 +140,7 @@ describe('e2e test suite', function () {
         const address1 = new cro.Address(keyPair.getPubKey());
         const address2 = new cro.Address(keyPair2.getPubKey());
         const randomAddress = new cro.Address(randomKeyPair.getPubKey());
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         const msgSend1 = new cro.bank.MsgSend({
             fromAddress: address1.account(),
@@ -202,7 +203,7 @@ describe('e2e test suite', function () {
             delegatorAddress: address1.account(),
         });
 
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         expect(client).to.be.not.undefined;
         const account = await client.getAccount(address1.account());
@@ -235,7 +236,7 @@ describe('e2e test suite', function () {
             delegatorAddress: address1.account(),
         });
 
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         expect(client).to.be.not.undefined;
         const account = await client.getAccount(address1.account());
@@ -282,7 +283,7 @@ describe('e2e test suite', function () {
             value: new cro.Coin('1000000000', Units.BASE),
         });
 
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         expect(client).to.be.not.undefined;
         const account = await client.getAccount(addressAccount.account());
@@ -318,7 +319,7 @@ describe('e2e test suite', function () {
             minSelfDelegation: null,
         });
 
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         expect(client).to.be.not.undefined;
         const account = await client.getAccount(address1.account());
@@ -352,7 +353,7 @@ describe('e2e test suite', function () {
             delegatorAddress: address1.account(),
         });
 
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         expect(client).to.be.not.undefined;
         const account = await client.getAccount(address1.account());
@@ -384,7 +385,7 @@ describe('e2e test suite', function () {
             delegatorAddress: address1.account(),
         });
 
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         expect(client).to.be.not.undefined;
         const account = await client.getAccount(address1.account());
@@ -415,7 +416,7 @@ describe('e2e test suite', function () {
             validatorAddress: address1.validator(),
         });
 
-        const client = await StargateClient.connect(`${testNode.httpEndpoint}:${testNode.httpPort}`);
+        const client = await cro.CroClient.connect();
 
         expect(client).to.be.not.undefined;
         const account = await client.getAccount(address1.account());

--- a/lib/src/client/client.spec.ts
+++ b/lib/src/client/client.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { fuzzyDescribe } from '../test/mocha-fuzzy/suite';
+
+import { CroNetwork, CroSDK } from '../core/cro';
+
+const cro = CroSDK({ network: CroNetwork.Testnet });
+
+describe('CroClient', function () {
+    describe('connect', function () {
+        fuzzyDescribe('should throw Error when the provided argument is not url', function (fuzzy) {
+            const testRunner = fuzzy(fuzzy.StringArg('test'));
+            testRunner(
+                async function (args0) {
+                    if (args0.valid) {
+                        return;
+                    }
+                    try {
+                        await cro.CroClient.connect(args0.value);
+                    } catch (e) {
+                        expect(e.toString()).to.be.contain(
+                            'ArgumentError: Expected `endpoint` to be of type `string` but received type',
+                        );
+                    }
+                },
+                { invalidArgsOnly: true },
+            );
+        });
+
+        context('When input is a string', function () {
+            it('should throw Error when the provided string is not a url', async function () {
+                try {
+                    await cro.CroClient.connect('invalid');
+                } catch (e) {
+                    expect(e.toString()).to.be.equals(
+                        'ArgumentError: Expected string `endpoint` to be an url, got `invalid`',
+                    );
+                }
+            });
+        });
+    });
+});

--- a/lib/src/client/client.ts
+++ b/lib/src/client/client.ts
@@ -1,0 +1,121 @@
+import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
+import {
+    StargateClient,
+    QueryClient,
+    AuthExtension,
+    BankExtension,
+    DistributionExtension,
+    StakingExtension,
+    setupAuthExtension,
+    setupBankExtension,
+    setupDistributionExtension,
+    setupStakingExtension,
+} from '@cosmjs/stargate';
+import { Account } from '@cosmjs/stargate/build/accounts';
+import { Coin } from '@cosmjs/stargate/build/codec/cosmos/base/v1beta1/coin';
+import { SearchTxFilter, SearchTxQuery } from '@cosmjs/stargate/build/search';
+import { Block, BroadcastTxResponse, IndexedTx, SequenceResponse } from '@cosmjs/stargate/build/stargateclient';
+import ow from 'ow';
+import { InitConfigurations } from '../core/cro';
+import { owUrl } from './ow.types';
+
+export interface ICroClient {
+    query(): (QueryClient & AuthExtension & BankExtension & DistributionExtension & StakingExtension) | undefined;
+    getChainId(): Promise<string>;
+    getHeight(): Promise<number>;
+    getAccount(searchAddress: string): Promise<Account | null>;
+    getAccountVerified(searchAddress: string): Promise<Account | null>;
+    getSequence(address: string): Promise<SequenceResponse>;
+    getBlock(height?: number): Promise<Block>;
+    getCroBalance(address: string): Promise<Coin>;
+    getTx(id: string): Promise<IndexedTx | null>;
+    searchTx(query: SearchTxQuery, filter?: SearchTxFilter): Promise<readonly IndexedTx[]>;
+    disconnect(): void;
+    broadcastTx(tx: Uint8Array): Promise<BroadcastTxResponse>;
+}
+
+export const croClient = function (config: InitConfigurations) {
+    return class CroClient implements ICroClient {
+        tmClient: Tendermint34Client;
+
+        baseDenom: string;
+
+        readonly txClient: StargateClient;
+
+        readonly queryClient:
+            | (QueryClient & AuthExtension & BankExtension & DistributionExtension & StakingExtension)
+            | undefined;
+
+        private constructor(tmClient: Tendermint34Client, txClient: StargateClient) {
+            this.txClient = txClient;
+            this.tmClient = tmClient;
+            this.queryClient = QueryClient.withExtensions(
+                tmClient,
+                setupAuthExtension,
+                setupBankExtension,
+                setupStakingExtension,
+                setupDistributionExtension,
+            );
+
+            this.baseDenom = config.network.coin.baseDenom;
+        }
+
+        public static async connect(endpoint: string = config.network.rpcUrl): Promise<CroClient> {
+            ow(endpoint, 'endpoint', owUrl);
+            const tmClient = await Tendermint34Client.connect(endpoint);
+            const txClient = await StargateClient.connect(endpoint);
+            return new CroClient(tmClient, txClient);
+        }
+
+        public disconnect(): void {
+            if (this.tmClient) this.tmClient.disconnect();
+            if (this.txClient) this.txClient.disconnect();
+        }
+
+        public query():
+            | (QueryClient & AuthExtension & BankExtension & DistributionExtension & StakingExtension)
+            | undefined {
+            return this.queryClient;
+        }
+
+        public async getChainId(): Promise<string> {
+            return this.txClient.getChainId();
+        }
+
+        public async getHeight(): Promise<number> {
+            return this.txClient.getHeight();
+        }
+
+        public async getAccount(searchAddress: string): Promise<Account | null> {
+            return this.txClient.getAccount(searchAddress);
+        }
+
+        public async getAccountVerified(searchAddress: string): Promise<Account | null> {
+            return this.txClient.getAccountVerified(searchAddress);
+        }
+
+        public async getSequence(address: string): Promise<SequenceResponse> {
+            return this.txClient.getSequence(address);
+        }
+
+        public async getBlock(height?: number): Promise<Block> {
+            return this.txClient.getBlock(height);
+        }
+
+        public async getCroBalance(address: string): Promise<Coin> {
+            return this.txClient.getBalance(address, this.baseDenom);
+        }
+
+        public async getTx(id: string): Promise<IndexedTx | null> {
+            return this.txClient.getTx(id);
+        }
+
+        public async searchTx(query: SearchTxQuery, filter?: SearchTxFilter): Promise<readonly IndexedTx[]> {
+            return this.txClient.searchTx(query, filter);
+        }
+
+        public async broadcastTx(tx: Uint8Array): Promise<BroadcastTxResponse> {
+            return this.txClient.broadcastTx(tx);
+        }
+    };
+};

--- a/lib/src/client/ow.types.ts
+++ b/lib/src/client/ow.types.ts
@@ -1,0 +1,6 @@
+import ow from 'ow';
+
+export const owUrl = ow.string.validate((val) => ({
+    validator: val.startsWith('http://') || val.startsWith('https://'),
+    message: (label) => `Expected ${label} to be an url, got \`${val}\``,
+}));

--- a/lib/src/core/cro.ts
+++ b/lib/src/core/cro.ts
@@ -1,5 +1,6 @@
 import ow from 'ow';
 
+import { croClient } from '../client/client';
 import { Network } from '../network/network';
 import { coin } from '../coin/coin';
 import { owCroSDKInitParams } from './ow.types';
@@ -24,6 +25,7 @@ export const CroSDK = function (configs: InitConfigurations) {
     ow(configs, 'configs', owCroSDKInitParams);
 
     return {
+        CroClient: croClient(configs),
         Coin: coin(configs),
         RawTransaction: rawTransaction(configs),
         Address: userAddress(configs),
@@ -71,6 +73,7 @@ export class CroNetwork {
             coinType: 1,
             account: 0,
         },
+        rpcUrl: 'https://testnet-croeseid.crypto.org:26657',
     };
 
     public static Mainnet: Network = {
@@ -87,6 +90,7 @@ export class CroNetwork {
             coinType: 394,
             account: 0,
         },
+        rpcUrl: 'https://mainnet.crypto.org:26657',
     };
 }
 

--- a/lib/src/network/network.ts
+++ b/lib/src/network/network.ts
@@ -12,4 +12,5 @@ export type Network = {
         coinType: number;
         account: number;
     };
+    rpcUrl: string;
 };

--- a/lib/src/network/ow.types.ts
+++ b/lib/src/network/ow.types.ts
@@ -16,4 +16,5 @@ export const owNetwork = () =>
             coinType: ow.number,
             account: ow.number,
         }),
+        rpcUrl: ow.string,
     });

--- a/lib/src/transaction/amino.spec.ts
+++ b/lib/src/transaction/amino.spec.ts
@@ -30,6 +30,7 @@ describe('Amino JSON sign mode', function () {
                     coinType: 1,
                     account: 0,
                 },
+                rpcUrl: '',
             },
         });
         const msg = new cro.bank.MsgSend({

--- a/lib/src/transaction/msg/bank/msgsend.spec.ts
+++ b/lib/src/transaction/msg/bank/msgsend.spec.ts
@@ -24,6 +24,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/distribution/MsgWithdrawDelegatorReward.spec.ts
+++ b/lib/src/transaction/msg/distribution/MsgWithdrawDelegatorReward.spec.ts
@@ -21,6 +21,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/distribution/MsgWithdrawValidatorCommission.spec.ts
+++ b/lib/src/transaction/msg/distribution/MsgWithdrawValidatorCommission.spec.ts
@@ -20,6 +20,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/gov/MsgDeposit.spec.ts
+++ b/lib/src/transaction/msg/gov/MsgDeposit.spec.ts
@@ -25,6 +25,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/gov/MsgSubmitProposal.spec.ts
+++ b/lib/src/transaction/msg/gov/MsgSubmitProposal.spec.ts
@@ -23,6 +23,7 @@ const PystaportTestNet: Network = {
         coinType: 1,
         account: 0,
     },
+    rpcUrl: '',
 };
 const cro = CroSDK({ network: PystaportTestNet });
 

--- a/lib/src/transaction/msg/gov/MsgVote.spec.ts
+++ b/lib/src/transaction/msg/gov/MsgVote.spec.ts
@@ -26,6 +26,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/gov/proposal/CancelSoftwareUpgradeProposal.spec.ts
+++ b/lib/src/transaction/msg/gov/proposal/CancelSoftwareUpgradeProposal.spec.ts
@@ -23,6 +23,7 @@ const PystaportTestNet: Network = {
         coinType: 1,
         account: 0,
     },
+    rpcUrl: '',
 };
 const cro = CroSDK({ network: PystaportTestNet });
 

--- a/lib/src/transaction/msg/staking/MsgBeginRedelegate.spec.ts
+++ b/lib/src/transaction/msg/staking/MsgBeginRedelegate.spec.ts
@@ -24,6 +24,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/staking/MsgCreateValidator.spec.ts
+++ b/lib/src/transaction/msg/staking/MsgCreateValidator.spec.ts
@@ -24,6 +24,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/staking/MsgDelegate.spec.ts
+++ b/lib/src/transaction/msg/staking/MsgDelegate.spec.ts
@@ -25,6 +25,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/staking/MsgEditValidator.spec.ts
+++ b/lib/src/transaction/msg/staking/MsgEditValidator.spec.ts
@@ -22,6 +22,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/msg/staking/MsgUndelegate.spec.ts
+++ b/lib/src/transaction/msg/staking/MsgUndelegate.spec.ts
@@ -25,6 +25,7 @@ const cro = CroSDK({
             coinType: 1,
             account: 0,
         },
+        rpcUrl: '',
     },
 });
 

--- a/lib/src/transaction/tx-custom-props.spec.ts
+++ b/lib/src/transaction/tx-custom-props.spec.ts
@@ -22,6 +22,7 @@ const TestNetwork: Network = {
         coinType: 1,
         account: 0,
     },
+    rpcUrl: '',
 };
 
 describe('Testing Tx signing with custom parameters', function () {

--- a/lib/src/transaction/tx-edgecase.spec.ts
+++ b/lib/src/transaction/tx-edgecase.spec.ts
@@ -22,6 +22,7 @@ const PystaportTestNet: Network = {
         coinType: 1,
         account: 0,
     },
+    rpcUrl: '',
 };
 
 const TestNetwork: Network = {
@@ -38,6 +39,7 @@ const TestNetwork: Network = {
         coinType: 1,
         account: 0,
     },
+    rpcUrl: '',
 };
 
 describe('Testing edge case Txs with 0 account numbers or 0 sequence', function () {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   "dependencies": {
     "@cosmjs/encoding": "0.23.1",
     "@cosmjs/math": "0.23.1",
+    "@cosmjs/stargate": "0.25.0-alpha.2",
+    "@cosmjs/tendermint-rpc": "0.25.0-alpha.2",
     "axios": "0.21.1",
     "bech32": "1.1.4",
     "big.js": "6.0.0",
@@ -60,7 +62,6 @@
     "secp256k1": "4.0.2"
   },
   "devDependencies": {
-    "@cosmjs/stargate": "0.24.0-alpha.9",
     "@types/bech32": "1.1.2",
     "@types/big.js": "6.0.0",
     "@types/bip32": "2.0.0",


### PR DESCRIPTION
Create a client wrapper over 'StargateClient' and 'QueryClient' from cosmosjs


Before users need to manually import cosmosjs client into their project and configure them to be compatible with our chain.
This can be the source of errors and it requires extra effort to use the SDK
- Need to find a cosmosjs version which is compatible with crypto.com chain version
- Make sure to uses the methods supported (ie use broadcast instead of StargateSigningClient to send tx)
- QueryClient needs to be initialise with the module supported manually 

The wrapper encapsulate the transactions client and query client into an object and expose the functions only supported.
No need also to import extra packages.
