### PR TITLE
Make rpcUrl - Prevent breaking existing functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.0.20
+- Make RpcURL optional - Prevent breaking previous functionalities
+
 ## v0.0.19
 - Release new testnet network croesied-3
 - Fix an issue which would create module error if the project has @cosmjs dependencies

--- a/lib/src/client/client.spec.ts
+++ b/lib/src/client/client.spec.ts
@@ -102,9 +102,10 @@ describe('CroClient', function () {
         context('Getting On-Chain details', function () {
             it('Should fetch correct details from the network', async function () {
                 nock.disableNetConnect();
-                nock(CroNetwork.Testnet.rpcUrl).persist(true).post('/').reply(200, statusQueryResponse);
+                const rpcUrl: string = CroNetwork.Testnet.rpcUrl ?? '';
+                nock(rpcUrl).persist(true).post('/').reply(200, statusQueryResponse);
 
-                const croHttpClient = await cro.CroClient.connect(CroNetwork.Testnet.rpcUrl);
+                const croHttpClient = await cro.CroClient.connect(rpcUrl);
 
                 expect(await croHttpClient.getChainId()).to.be.equal('testnet-croeseid-2');
                 expect(typeof (await croHttpClient.getHeight())).to.equal('number');
@@ -121,8 +122,9 @@ describe('CroClient', function () {
             });
 
             function remockNockForAbciQuery() {
+                const rpcUrl: string = CroNetwork.Testnet.rpcUrl ?? '';
                 nock.cleanAll();
-                nock(CroNetwork.Testnet.rpcUrl).persist(true).post('/').reply(200, abciQueryResponse);
+                nock(rpcUrl).persist(true).post('/').reply(200, abciQueryResponse);
             }
         });
     });

--- a/lib/src/client/client.ts
+++ b/lib/src/client/client.ts
@@ -60,7 +60,7 @@ export const croClient = function (config: InitConfigurations) {
             this.baseDenom = config.network.coin.baseDenom;
         }
 
-        public static async connect(endpoint: string = config.network.rpcUrl): Promise<CroClient> {
+        public static async connect(endpoint: string = config.network.rpcUrl ?? ''): Promise<CroClient> {
             ow(endpoint, 'endpoint', owUrl);
             const tmClient = await Tendermint34Client.connect(endpoint);
             const txClient = await StargateClient.connect(endpoint);

--- a/lib/src/network/network.ts
+++ b/lib/src/network/network.ts
@@ -12,5 +12,5 @@ export type Network = {
         coinType: number;
         account: number;
     };
-    rpcUrl: string;
+    rpcUrl?: string;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crypto-com/chain-jslib",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Crypto.org Chain JavaScript library",
   "author": "Crypto.org <chain@crypto.org>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Making rpcUrl required did break existing wallets that were persisted in the DB before without that property.

`Expected property property 'rpcUrl' to be of type 'string' but received type 'undefined'`